### PR TITLE
LPS-89093 Add logic to verify and apply the portal startup delay

### DIFF
--- a/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/instance/lifecycle/IndexOnStartupPortalInstanceLifecycleListener.java
+++ b/modules/apps/portal-search/portal-search/src/main/java/com/liferay/portal/search/internal/instance/lifecycle/IndexOnStartupPortalInstanceLifecycleListener.java
@@ -24,6 +24,7 @@ import com.liferay.portal.kernel.search.SearchException;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.Props;
 import com.liferay.portal.kernel.util.PropsKeys;
+import com.liferay.portal.kernel.util.Time;
 
 /**
  * @author Michael C. Han
@@ -41,10 +42,22 @@ public class IndexOnStartupPortalInstanceLifecycleListener
 
 	@Override
 	public void portalInstanceRegistered(Company company) throws Exception {
-		if (!GetterUtil.getBoolean(_props.get(PropsKeys.INDEX_ON_STARTUP))) {
-			return;
-		}
+		if (_indexOnStartup()) {
+			_waitIndexOnStartupDelay();
 
+			_reindex(company);
+		}
+	}
+
+	private long _getIndexOnStartupDelay() {
+		return GetterUtil.getLong(_props.get(PropsKeys.INDEX_ON_STARTUP_DELAY));
+	}
+
+	private boolean _indexOnStartup() {
+		return GetterUtil.getBoolean(_props.get(PropsKeys.INDEX_ON_STARTUP));
+	}
+
+	private void _reindex(Company company) {
 		try {
 			_indexWriterHelper.reindex(
 				UserConstants.USER_ID_DEFAULT,
@@ -53,6 +66,14 @@ public class IndexOnStartupPortalInstanceLifecycleListener
 		}
 		catch (SearchException se) {
 			_log.error("Unable to reindex on activation", se);
+		}
+	}
+
+	private void _waitIndexOnStartupDelay() throws InterruptedException {
+		long delay = _getIndexOnStartupDelay();
+
+		if (delay > 0) {
+			Thread.sleep(Time.SECOND * delay);
 		}
 	}
 


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-89093

----------------------------
Class IndexOnStartupIndexerServiceCustomizer.addingService
- All indexers have the propertie "index.on.startup = true" by default;
- Creates the IndexOnStartupPortalInstanceLifecycleListener for each indexer and registers it in serviceRegistration;

----------------------------
Class IndexOnStartupPortalInstanceLifecycleListener.portalInstanceRegistered
- For all indexers do not enter the _indexWriterHelper.reindex method if the propertie is false;
- Stack:
1.     IndexWriterHelperImpl
2.     ReindexSingleIndexerBackgroundTaskExecutor
3.     Class Indexer of respective indexer

---------------------------

A logic was implemented to wait for a set time in the "index.on.startup.delay" property before reindexing the registry.

**Setting a delay does not really solve the problems.
Most records are reindexed, but not all.
At each startup a different amount of records are reindexed.
Still have the intermittent problem that some records are not reindexed.**